### PR TITLE
Enable configuration of ELB health check parameters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,19 @@ search:
       action :create
     end
 
+You can configure the `health check` parameters from the defaults by specifying
+the `health_check` attribute with a hash:
+
+    elb_load_balancer "ap-tcp-frontend" do
+      aws_access_key        aws['aws_access_key_id']
+      aws_secret_access_key aws['aws_secret_access_key']
+      instances             ['i-xxxxx', 'i-xxxxx']
+      region                'ap-southeast-1'
+      listeners             [{"InstancePort" => 1234, "Protocol" => "TCP", "LoadBalancerPort" => 1234}]
+      health_check          [{"HealthyThreshold" => 10, "Interval" => 30, "Target" => "HTTP:80/ping", "Timeout" => 5, "UnhealthyThreshold" =>2}]
+      action :create
+    end
+
 You can also do SSL, but it's a little funky.
 
 First, you have to [upload your cert](http://docs.amazonwebservices.com/ElasticLoadBalancing/latest/DeveloperGuide/index.html?US_SettingUpLoadBalancerHTTPSIntegrated.html).

--- a/resources/load_balancer.rb
+++ b/resources/load_balancer.rb
@@ -9,3 +9,4 @@ attribute :listeners,             :kind_of => Array,  :default => [{"InstancePor
 attribute :instances,             :kind_of => Array
 attribute :search_query,          :kind_of => String
 attribute :timeout,                                   :default => 60
+attribute :health_check,          :kind_of => Array, :default => [{"HealthyThreshold" => 10, "Interval" => 30, "Target" => "HTTP:80/", "Timeout" => 5, "UnhealthyThreshold" => 2}]


### PR DESCRIPTION
Adds an 'health_check' attribute to the ELB resource provider to
configure ELB health checks in a recipe.
