### PR TITLE
Updated metadata.rb to include name

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,3 +4,4 @@ license          "Apache 2.0"
 description      "Configure Elastic Load Balancers at AWS"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "0.1"
+name             "elb"


### PR DESCRIPTION
Berkshelf will explode without it.
